### PR TITLE
Prevent form submission on validation fail

### DIFF
--- a/playground/src/AdvancedForm/index.jsx
+++ b/playground/src/AdvancedForm/index.jsx
@@ -52,7 +52,7 @@ const AdvancedForm = () => {
 
 	return (
 		<FormProvider context={formContext}>
-			<form onSubmit={(e) => setFormData(handleSubmit(e))}>
+			<form onSubmit={handleSubmit(setFormData)}>
 				<h2>Advanced form (multiple re-usable file)</h2>
 				{toggle && (
 					<>

--- a/playground/src/SimpleForm.jsx
+++ b/playground/src/SimpleForm.jsx
@@ -61,7 +61,7 @@ const SimpleForm = () => {
 
 	return (
 		<FormProvider context={formContext}>
-			<form onSubmit={(e) => setFormData(handleSubmit(e))}>
+			<form onSubmit={handleSubmit(setFormData)}>
 				<h2>Simple form (single file)</h2>
 				{toggle && (
 					<>

--- a/src/hooks/useForm.jsx
+++ b/src/hooks/useForm.jsx
@@ -430,22 +430,20 @@ const useForm = ({ validateOnChange = false } = {}) => {
 	/**
 	 * @function
 	 * @name handleSubmit
-	 * @description A handler used to apply validation to each controlled input of the form and return their value if all are valid.
+	 * @description A handler method which applies validation to all the controlled fields and calls the callback parameter if the form is valid.
 	 *
 	 * @author Timothée Simon-Franza
 	 *
-	 * @param {object} event The "form submit" event to handle.
-	 *
-	 * @returns {object}
+	 * @param {func} callback The callback method to call if the form is valid.
 	 */
-	const handleSubmit = useCallback((event) => {
-		event.preventDefault();
+	const handleSubmit = useCallback((callback) => (event) => {
+		event?.preventDefault();
 		validateForm();
 
-		return isFormValid()
-			? getFormValues()
-			: null;
-	}, [isFormValid, getFormValues, validateForm]);
+		if (isFormValid()) {
+			callback(getFormValues());
+		}
+	}, [getFormValues, isFormValid, validateForm]);
 
 	/**
 	 * @function

--- a/tests/hooks/useForm.test.js
+++ b/tests/hooks/useForm.test.js
@@ -848,7 +848,7 @@ describe('useForm hook', () => {
 	});
 
 	describe('handleSubmit', () => {
-		it('should prevent the default form submission event', () => {
+		it('should prevent the default form submission event.', () => {
 			const event = { preventDefault: () => {} };
 			const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
@@ -857,6 +857,21 @@ describe('useForm hook', () => {
 			});
 
 			expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should return null if form is invalid.', () => {
+			const isRequiredValidator = jest.fn().mockImplementation((value) => (value.trim().length === 0 ? 'required' : ''));
+			const dummyFieldRef = { name: 'dummy_field', rules: { required: isRequiredValidator } };
+			const event = { preventDefault: () => {} };
+			let submitResult;
+
+			render(<input {...sut.register(dummyFieldRef)} />);
+
+			act(() => {
+				submitResult = sut.handleSubmit(event);
+			});
+
+			expect(submitResult).toEqual(null);
 		});
 
 		it('should return the result of the getFormValues method', () => {
@@ -883,8 +898,36 @@ describe('useForm hook', () => {
 		});
 	});
 
+	describe('isFormValid', () => {
+		it('should return false if at least one validation check fails', () => {
+			const isRequiredValidator = jest.fn().mockImplementation((value) => (value.trim().length === 0 ? 'required' : ''));
+			const dummyFieldRef = { name: 'dummy_field', rules: { required: isRequiredValidator } };
+
+			render(<input {...sut.register(dummyFieldRef)} />);
+
+			expect(sut.isFormValid()).toEqual(false);
+		});
+
+		it('should return true if no validation rule has been registered', () => {
+			const isRequiredValidator = jest.fn().mockImplementation((value) => (value.trim().length === 0 ? 'required' : ''));
+			const dummyFieldRef = { defaultValue: 'abcd', name: 'dummy_field', rules: { required: isRequiredValidator } };
+
+			render(<input {...sut.register(dummyFieldRef)} />);
+
+			expect(sut.isFormValid()).toEqual(true);
+		});
+
+		it('should return true if all validation checks succeed', () => {
+			const dummyFieldRef = { name: 'dummy_field', rules: {} };
+
+			render(<input {...sut.register(dummyFieldRef)} />);
+
+			expect(sut.isFormValid()).toEqual(true);
+		});
+	});
+
 	describe('getFieldsRefs', () => {
-		it('should return the current list of referenced fields', () => {
+		it('should return the current list of referenced fields.', () => {
 			const dummyFormFieldsRefs = [
 				{ id: 1, name: 'firstname', rules: {} },
 				{ id: 2, name: 'lastname', rules: {} },

--- a/tests/hooks/useForm.test.js
+++ b/tests/hooks/useForm.test.js
@@ -853,29 +853,31 @@ describe('useForm hook', () => {
 			const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
 
 			act(() => {
-				sut.handleSubmit(event);
+				sut.handleSubmit(() => {})(event);
 			});
 
 			expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
 		});
 
-		it('should return null if form is invalid.', () => {
+		it('should not call the provided callback method if the form is invalid.', () => {
 			const isRequiredValidator = jest.fn().mockImplementation((value) => (value.trim().length === 0 ? 'required' : ''));
 			const dummyFieldRef = { name: 'dummy_field', rules: { required: isRequiredValidator } };
 			const event = { preventDefault: () => {} };
-			let submitResult;
+			const callbackMock = jest.fn();
 
 			render(<input {...sut.register(dummyFieldRef)} />);
 
 			act(() => {
-				submitResult = sut.handleSubmit(event);
+				sut.handleSubmit(callbackMock)(event);
 			});
 
-			expect(submitResult).toEqual(null);
+			expect(callbackMock).not.toHaveBeenCalled();
 		});
 
-		it('should return the result of the getFormValues method', () => {
+		it('should call the provided callback method with the result of the getFormValues method.', () => {
 			const event = { preventDefault: () => {} };
+			const callbackMock = jest.fn();
+
 			const dummyFormFieldsRefs = [
 				{ id: 1, name: 'firstname' },
 				{ id: 2, name: 'lastname' },
@@ -888,13 +890,13 @@ describe('useForm hook', () => {
 					{dummyFormFieldsRefs.map((field) => <input key={field.id} {...sut.register(field)} />)}
 				</>
 			);
-			let submitResult;
 
 			act(() => {
-				submitResult = sut.handleSubmit(event);
+				sut.handleSubmit(callbackMock)(event);
 			});
 
-			expect(submitResult).toEqual(sut.getFormValues());
+			expect(callbackMock).toHaveBeenCalledTimes(1);
+			expect(callbackMock).toHaveBeenCalledWith(sut.getFormValues());
 		});
 	});
 


### PR DESCRIPTION
The useForm hook now provides a new isFormValid method, and its handleSubmit method has been updated.

From now on, the handleSubmit doesn't return the form's values but calls a provided callback method if the form is valid.
If at least one field's validation check fails, the callback method isn't called at all.